### PR TITLE
Potential fix for code scanning alert no. 4: Untrusted XML is read insecurely

### DIFF
--- a/TaxAssistant.JPK/Client/Pages/ImportJpk.razor
+++ b/TaxAssistant.JPK/Client/Pages/ImportJpk.razor
@@ -74,7 +74,7 @@ else if (importResult != null)
 
             response.EnsureSuccessStatusCode();
 
-            var stringResponse = await response.Content.ReadFromJsonAsync<ImportResult>(options);
+            importResult = await response.Content.ReadFromJsonAsync<ImportResult>(options);
         }
         finally
         {

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -155,7 +155,8 @@ namespace TaxAssistant.JPK.Server.Controllers
 
             var settings = new XmlReaderSettings
             {
-                DtdProcessing = DtdProcessing.Prohibit
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null
             };
 
             using var xmlReader = XmlReader.Create(new StringReader(xmlString), settings);

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -152,11 +152,14 @@ namespace TaxAssistant.JPK.Server.Controllers
             var xmlString = HttpUtility.HtmlDecode(content);
 
             var xmlDocument = new XmlDocument();
-            var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit };
-            using (var reader = XmlReader.Create(new StringReader(xmlString), settings))
+
+            var settings = new XmlReaderSettings
             {
-                xmlDocument.Load(reader);
-            }
+                DtdProcessing = DtdProcessing.Prohibit
+            };
+
+            using var xmlReader = XmlReader.Create(new StringReader(xmlString), settings);
+            xmlDocument.Load(xmlReader);
 
             if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
             {
@@ -169,8 +172,8 @@ namespace TaxAssistant.JPK.Server.Controllers
             }
 
             var serializer = new XmlSerializer(type);
-            var reader = new StringReader(xmlString);
-            var model = serializer.Deserialize(reader);
+            var stringReader = new StringReader(xmlString);
+            var model = serializer.Deserialize(stringReader);
 
             return model;
         }

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -175,10 +175,11 @@ namespace TaxAssistant.JPK.Server.Controllers
             }
 
             var serializer = new XmlSerializer(type);
-            var stringReader = new StringReader(xmlString);
-            var model = serializer.Deserialize(stringReader);
-
-            return model;
+            using (var xmlReader = XmlReader.Create(new StringReader(xmlString), settings))
+            {
+                var model = serializer.Deserialize(xmlReader);
+                return model;
+            }
         }
     }
 }

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -162,6 +162,7 @@ namespace TaxAssistant.JPK.Server.Controllers
             using (var xmlReader = XmlReader.Create(new StringReader(xmlString), settings))
             {
                 xmlDocument.Load(xmlReader);
+                xmlReader.Close(); // Ensure the reader is closed after use
 
                 if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
                 {

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -162,21 +162,18 @@ namespace TaxAssistant.JPK.Server.Controllers
             using (var xmlReader = XmlReader.Create(new StringReader(xmlString), settings))
             {
                 xmlDocument.Load(xmlReader);
-            }
 
-            if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
-            {
-                throw new NotImplementedException($"XML has no namespace");
-            }
+                if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
+                {
+                    throw new NotImplementedException($"XML has no namespace");
+                }
 
-            if (!_namespaces.TryGetValue(xmlDocument.DocumentElement.NamespaceURI, out var type))
-            {
-                throw new NotImplementedException($"Namespace \"{xmlDocument.DocumentElement.NamespaceURI}\" has no handler");
-            }
+                if (!_namespaces.TryGetValue(xmlDocument.DocumentElement.NamespaceURI, out var type))
+                {
+                    throw new NotImplementedException($"Namespace \"{xmlDocument.DocumentElement.NamespaceURI}\" has no handler");
+                }
 
-            var serializer = new XmlSerializer(type);
-            using (var xmlReader = XmlReader.Create(new StringReader(xmlString), settings))
-            {
+                var serializer = new XmlSerializer(type);
                 var model = serializer.Deserialize(xmlReader);
                 return model;
             }

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -162,7 +162,9 @@ namespace TaxAssistant.JPK.Server.Controllers
             using (var xmlReader = XmlReader.Create(new StringReader(xmlString), settings))
             {
                 xmlDocument.Load(xmlReader);
+                xmlReader.Close();
             }
+
             if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
             {
                 throw new NotImplementedException($"XML has no namespace");

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -30,6 +30,15 @@ namespace TaxAssistant.JPK.Server.Controllers
         private readonly IRepository<Fa> _faRepository;
         private readonly IRepository<Import> _importRepository;
 
+        private readonly IDictionary<string, Type> _namespaces = new Dictionary<string, Type>
+        {
+            { "http://jpk.mf.gov.pl/wzor/2016/10/26/10262/", typeof(JPK_PKPIR) },
+            { "http://crd.gov.pl/wzor/2020/05/08/9393/", typeof(JPK_V7M_1) },
+            { "http://crd.gov.pl/wzor/2021/12/27/11148/", typeof(JPK_V7M_2) },
+            { "http://jpk.mf.gov.pl/wzor/2022/02/01/02011/", typeof(JPK_EWP) },
+            { "http://jpk.mf.gov.pl/wzor/2022/02/17/02171/", typeof(JPK_FA) }
+        };
+
         public ImportController(
             ILogger<ImportController> logger,
             IJpkAdapter<JPK_PKPIR, Kpir> kpirAdapter,
@@ -96,7 +105,7 @@ namespace TaxAssistant.JPK.Server.Controllers
                     }
                     default:
                     {
-                        throw new NotImplementedException($"No adapter for {result.GetType().Name}");
+                        throw new NotImplementedException($"No adapter for {result?.GetType().Name}");
                     }
                 }
 
@@ -133,16 +142,7 @@ namespace TaxAssistant.JPK.Server.Controllers
             }
         }
 
-        private IDictionary<string, Type> _namespaces = new Dictionary<string, Type>
-        {
-            { "http://jpk.mf.gov.pl/wzor/2016/10/26/10262/", typeof(JPK_PKPIR) },
-            { "http://crd.gov.pl/wzor/2020/05/08/9393/", typeof(JPK_V7M_1) },
-            { "http://crd.gov.pl/wzor/2021/12/27/11148/", typeof(JPK_V7M_2) },
-            { "http://jpk.mf.gov.pl/wzor/2022/02/01/02011/", typeof(JPK_EWP) },
-            { "http://jpk.mf.gov.pl/wzor/2022/02/17/02171/", typeof(JPK_FA) }
-        };
-
-        private object Deserialize(string content)
+        private object? Deserialize(string content)
         {
             if (string.IsNullOrEmpty(content))
             {
@@ -159,8 +159,10 @@ namespace TaxAssistant.JPK.Server.Controllers
                 XmlResolver = null
             };
 
-            using var xmlReader = XmlReader.Create(new StringReader(xmlString), settings);
-            xmlDocument.Load(xmlReader);
+            using (var xmlReader = XmlReader.Create(new StringReader(xmlString), settings))
+            {
+                xmlDocument.Load(xmlReader);
+            }
 
             if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
             {

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -151,18 +151,17 @@ namespace TaxAssistant.JPK.Server.Controllers
 
             var xmlString = HttpUtility.HtmlDecode(content);
 
-            var xmlDocument = new XmlDocument();
-
             var settings = new XmlReaderSettings
             {
                 DtdProcessing = DtdProcessing.Prohibit,
                 XmlResolver = null
             };
 
+            var xmlDocument = new XmlDocument();
+
             using (var xmlReader = XmlReader.Create(new StringReader(xmlString), settings))
             {
                 xmlDocument.Load(xmlReader);
-                xmlReader.Close();
             }
             if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
             {

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -162,22 +162,27 @@ namespace TaxAssistant.JPK.Server.Controllers
             using (var xmlReader = XmlReader.Create(new StringReader(xmlString), settings))
             {
                 xmlDocument.Load(xmlReader);
-                xmlReader.Close(); // Ensure the reader is closed after use
-
-                if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
-                {
-                    throw new NotImplementedException($"XML has no namespace");
-                }
-
-                if (!_namespaces.TryGetValue(xmlDocument.DocumentElement.NamespaceURI, out var type))
-                {
-                    throw new NotImplementedException($"Namespace \"{xmlDocument.DocumentElement.NamespaceURI}\" has no handler");
-                }
-
-                var serializer = new XmlSerializer(type);
-                var model = serializer.Deserialize(xmlReader);
-                return model;
+                xmlReader.Close();
             }
+            if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
+            {
+                throw new NotImplementedException($"XML has no namespace");
+            }
+
+            if (!_namespaces.TryGetValue(xmlDocument.DocumentElement.NamespaceURI, out var type))
+            {
+                throw new NotImplementedException($"Namespace \"{xmlDocument.DocumentElement.NamespaceURI}\" has no handler");
+            }
+
+            var serializer = new XmlSerializer(type);
+            object? model = null;
+            using (var xmlReader = XmlReader.Create(new StringReader(xmlString), settings))
+            {
+                model = serializer.Deserialize(xmlReader);
+                xmlReader.Close();
+            }
+
+            return model;
         }
     }
 }

--- a/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
+++ b/TaxAssistant.JPK/Server/Controllers/Action/ImportController.cs
@@ -152,7 +152,11 @@ namespace TaxAssistant.JPK.Server.Controllers
             var xmlString = HttpUtility.HtmlDecode(content);
 
             var xmlDocument = new XmlDocument();
-            xmlDocument.LoadXml(xmlString);
+            var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit };
+            using (var reader = XmlReader.Create(new StringReader(xmlString), settings))
+            {
+                xmlDocument.Load(reader);
+            }
 
             if (string.IsNullOrEmpty(xmlDocument.DocumentElement?.NamespaceURI))
             {

--- a/TaxAssistant.JPK/Server/Program.cs
+++ b/TaxAssistant.JPK/Server/Program.cs
@@ -14,6 +14,9 @@ using TaxAssistant.JPK.Shared.Model.Database.Ewp;
 using TaxAssistant.JPK.Shared.Model.Database.Fa;
 using TaxAssistant.JPK.Shared.Model.Database.Kpir;
 using TaxAssistant.JPK.Shared.Model.Domain.Company;
+using TaxAssistant.JPK.Shared.Model.Xml.JPK_EWP;
+using TaxAssistant.JPK.Shared.Model.Xml.JPK_FA;
+using TaxAssistant.JPK.Shared.Model.Xml.JPK_PKPIR;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -27,12 +30,16 @@ builder.Services.AddControllersWithViews().AddJsonOptions(options =>
 });
 
 builder.Services.AddRazorPages();
-builder.Services.AddScoped<KpirAdapter>();
+
+builder.Services.AddScoped<IJpkAdapter<JPK_PKPIR, Kpir>, KpirAdapter>();
 builder.Services.AddScoped<IRepository<Kpir>, KpirRepository>();
-builder.Services.AddScoped<EwpAdapter>();
+
+builder.Services.AddScoped<IJpkAdapter<JPK_EWP, Ewp>, EwpAdapter>();
 builder.Services.AddScoped<IRepository<Ewp>, EwpRepository>();
-builder.Services.AddScoped<FaAdapter>();
+
+builder.Services.AddScoped<IJpkAdapter<JPK_FA, Fa>, FaAdapter>();
 builder.Services.AddScoped<IRepository<Fa>, FaRepository>();
+
 builder.Services.AddScoped<IRepository<Import>, ImportRepository>();
 builder.Services.AddScoped<IRepository<Company>, CompanyRepository>();
 


### PR DESCRIPTION
Potential fix for [https://github.com/mateuszlor/TaxAssistant/security/code-scanning/4](https://github.com/mateuszlor/TaxAssistant/security/code-scanning/4)

To fix the problem, we need to ensure that DTD processing is disabled when loading the XML content. This can be achieved by setting the `XmlReaderSettings.DtdProcessing` property to `DtdProcessing.Prohibit` and using an `XmlReader` with these settings to load the XML content into the `XmlDocument`.

1. Create an `XmlReaderSettings` object and set its `DtdProcessing` property to `DtdProcessing.Prohibit`.
2. Use the `XmlReader.Create` method with these settings to create an `XmlReader` for the XML content.
3. Load the XML content into the `XmlDocument` using the `XmlReader`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
